### PR TITLE
crdroid: Make MatLog an optional package

### DIFF
--- a/config/crdroid.mk
+++ b/config/crdroid.mk
@@ -40,9 +40,13 @@ PRODUCT_PACKAGES += \
     ThemePicker \
     OmniJaws \
     OmniStyle \
-    MatLog \
     QuickAccessWallet \
     StitchImage
+
+ifneq ($(TARGET_EXCLUDES_MATLOG),true)
+PRODUCT_PACKAGES += \
+    MatLog
+endif
 
 # Fonts
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
* The builder may not always need it or simply want to remove it